### PR TITLE
docs: harmonize Markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,81 @@
 # OpenWrt Ansible
 
-Ce dépôt facilite l'administration de routeurs **OpenWrt** avec **Ansible** dans une approche GitOps. Il fournit des rôles et playbooks réutilisables pour déployer une configuration cohérente et versionnée.
-
-## Table des matières
-1. [Prérequis](#prérequis)
-2. [Installation rapide](#installation-rapide)
-3. [Inventaires](#inventaires)
-4. [Structure du dépôt](#structure-du-dépôt)
-5. [Rôles disponibles](#rôles-disponibles)
-6. [Documentation complémentaire](#documentation-complémentaire)
-7. [Licence](#licence)
+Ce dépôt fournit une collection de rôles Ansible et de playbooks pour gérer des routeurs **OpenWrt** selon des principes **GitOps**. Toutes les modifications passent par Git et peuvent être auditées.
 
 ## Prérequis
-- Linux ou macOS avec accès à Internet
-- Ansible (ansible-core \u2265 2.14)
-- Python 3 et `pip`
+- Linux ou macOS avec Git, Python ≥3.11 et ansible-core ≥2.14
 - Accès SSH par clé publique vers `root@routeur`
-- Connectivité IPv4/IPv6 vers les routeurs
+- Connexion IPv4/IPv6 vers les équipements
+- Paquets supplémentaires installés sur le routeur : `python3-light` et `openssh-sftp-server` (via `playbooks/bootstrap.yml`)
 
 ## Installation rapide
-1. Cloner ce dépôt :
+1. Cloner le dépôt et installer les collections :
    ```bash
-   git clone https://example.com/openwrt-ansible-ci-vlan-imagebuilder.git
-   cd openwrt-ansible-ci-vlan-imagebuilder
-   ```
-2. Installer les collections Ansible :
-   ```bash
+   git clone https://example.com/openwrt-ansible-ci.git
+   cd openwrt-ansible-ci
    ansible-galaxy collection install -r requirements.yml
    ```
-3. Enregistrer la clé hôte du routeur si nécessaire :
+2. Enregistrer la clé hôte et lancer le bootstrap :
    ```bash
    ssh-keyscan -H routeur >> ~/.ssh/known_hosts
-   # ou établir une connexion SSH initiale
-   # ssh root@routeur
-   ```
-4. Préparer les routeurs (installe `python3-light` et `openssh-sftp-server`) :
-   ```bash
    ansible-playbook -i inventories/production/hosts.ini playbooks/bootstrap.yml
    ```
-5. Adapter les variables :
+3. Adapter l’inventaire et les variables :
    ```bash
-   $EDITOR group_vars/openwrt.yml inventories/production/hosts.ini
+   $EDITOR inventories/production/hosts.ini group_vars/openwrt.yml
    ```
-6. Appliquer la configuration :
+4. Appliquer la configuration :
    ```bash
    ansible-playbook -i inventories/production/hosts.ini playbooks/site.yml
    ```
 
 ## Inventaires
-Trois inventaires sont fournis :
-- **lab** : tests et expérimentations
-- **staging** : préproduction
-- **production** : déploiement
+Trois environnements sont fournis :
 
-Sélectionnez l'inventaire voulu avec l'option `-i` :
+| Inventaire  | Usage           |
+|-------------|-----------------|
+| `lab`       | tests locaux    |
+| `staging`   | préproduction   |
+| `production`| déploiement     |
+
+Sélectionner l’inventaire avec `-i` :
+
 ```bash
 ansible-playbook -i inventories/lab/hosts.ini playbooks/site.yml
 ```
 
 ## Structure du dépôt
 ```text
-ansible.cfg                 # Réglages par défaut
-requirements.yml            # Collections Ansible
-inventories/
-  lab/hosts.ini             # Inventaire de test
-  staging/hosts.ini         # Inventaire de préproduction
-  production/hosts.ini      # Inventaire d'exemple
-group_vars/
-  openwrt.yml               # Variables communes
-playbooks/
-  bootstrap.yml             # Prépare les cibles
-  site.yml                  # Applique les rôles
-roles/                      # Rôles Ansible
+ansible.cfg                 # paramètres Ansible
+requirements.yml            # collections
+inventories/                # inventaires lab/staging/production
+group_vars/                 # variables partagées
+playbooks/                  # bootstrap + site
+roles/                      # rôles Ansible
+docs/                       # documentation
+imagebuilder/               # génération d’images personnalisées
 ```
 
 ## Rôles disponibles
-- [base](roles/base/README.md) : configuration de base
-- [packages](roles/packages/README.md) : paquets supplémentaires
-- [ntp](roles/ntp/README.md) : synchronisation du temps
-- [logging](roles/logging/README.md) : redirection des logs
-- [ids](roles/ids/README.md) : intrusion detection (Suricata)
-- [backup](roles/backup/README.md) : sauvegarde de la configuration
-- [fail2ban](roles/fail2ban/README.md) : protection fail2ban
+- [base](roles/base/README.md) : système de base (hostname, timezone, clés SSH)
+- [packages](roles/packages/README.md) : installation de paquets
+- [ntp](roles/ntp/README.md) : synchronisation horaire
+- [logging](roles/logging/README.md) : redirection des journaux
+- [ids](roles/ids/README.md) : détection d’intrusion Suricata
+- [backup](roles/backup/README.md) : sauvegardes programmées
+- [fail2ban](roles/fail2ban/README.md) : protection par bannissement
 - [ha](roles/ha/README.md) : haute disponibilité VRRP
-- [network](roles/network/README.md) : interfaces, VLANs, firewall
-- [dnsdhcp](roles/dnsdhcp/README.md) : DNS et DHCP
-- [routing](roles/routing/README.md) : routage dynamique
-- [wireless](roles/wireless/README.md) : WiFi
-- [firewall](roles/firewall/README.md) : règles additionnelles
+- [network](roles/network/README.md) : interfaces, VLANs, WireGuard
+- [dnsdhcp](roles/dnsdhcp/README.md) : service DNS/DHCP
+- [routing](roles/routing/README.md) : routage dynamique Bird2
+- [wireless](roles/wireless/README.md) : configuration Wi-Fi
+- [firewall](roles/firewall/README.md) : règles pare-feu supplémentaires
+- [monitoring](roles/monitoring/README.md) : métriques collectd
 
-Chaque rôle dispose de sa documentation complète dans `roles/<nom>/README.md`
-
-## Documentation complémentaire
-- [Tutoriel détaillé](docs/deploiement-openwrt.md)
-- [Exemples de configuration](docs/examples.md)
+## Documentation
+- [Guide de déploiement](docs/deploiement-openwrt.md)
+- [Exemples d’utilisation](docs/examples.md)
+- [ImageBuilder](imagebuilder/README.md)
 
 ## Licence
 Ce projet est distribué sous licence MIT. Voir [LICENSE](LICENSE).

--- a/docs/deploiement-openwrt.md
+++ b/docs/deploiement-openwrt.md
@@ -1,36 +1,32 @@
 # Guide de déploiement OpenWrt Ansible
 
-## Objectif
-Ce document explique pas à pas comment utiliser ce dépôt Ansible pour configurer des routeurs OpenWrt via un flux GitOps.
+Ce guide décrit la mise en œuvre de ce dépôt pour configurer des routeurs OpenWrt dans une démarche GitOps.
 
 ## 1. Architecture du dépôt
-- `inventories/` : définitions des hôtes (`hosts.ini`) pour `lab`, `staging`, `production`.
-- `group_vars/openwrt.yml` : variables communes (réseau, paquets, WireGuard, VLANs…).
-- `playbooks/bootstrap.yml` : installe `python3-light` et `openssh-sftp-server` sur les routeurs.
-- `playbooks/site.yml` : applique l’ensemble des rôles (`base`, `network`, `firewall`, etc.).
-- `imagebuilder/` : génère des images OpenWrt personnalisées.
+- `inventories/<env>/hosts.ini` : inventaire pour `lab`, `staging`, `production`
+- `group_vars/openwrt.yml` : variables communes
+- `playbooks/bootstrap.yml` : installe `python3-light` et `openssh-sftp-server`
+- `playbooks/site.yml` : applique l’ensemble des rôles
+- `imagebuilder/` : script pour créer des images OpenWrt personnalisées
 
 ## 2. Prérequis
-- Poste Linux ou macOS avec Git, Python ≥3.11 et Ansible ≥2.14.
-- Accès SSH clé publique vers `root@routeur`.
-- Connectivité IPv4/IPv6 vers les routeurs cibles.
+- Poste Linux ou macOS avec Git, Python ≥ 3.11 et Ansible ≥ 2.14
+- Accès SSH par clé publique vers `root@routeur`
+- Connectivité réseau vers les équipements
 
-## 3. Clonage et installation
+## 3. Installation
 ```bash
 git clone https://example.com/openwrt-ansible-ci.git
 cd openwrt-ansible-ci
 ansible-galaxy collection install -r requirements.yml
 ```
 
-## 4. Gestion des secrets (SOPS/age)
-
-1. Générer une clé age :
-
+## 4. Gestion des secrets avec SOPS/age
+1. Générer une clé :
    ```bash
    age-keygen -o ~/.config/sops/age/keys.txt
    ```
 2. Créer `.sops.yaml` :
-
    ```yaml
    keys:
      - age1example...
@@ -38,21 +34,18 @@ ansible-galaxy collection install -r requirements.yml
      - path_regex: inventories/.*/group_vars/.*secrets.yml$
        age: age1example...
    ```
-3. Chiffrer un fichier de variables sensibles :
-
+3. Chiffrer un fichier :
    ```bash
    sops inventories/production/group_vars/secrets.yml
    ```
 
-## 5. Construction d’une image OpenWrt personnalisée
-
+## 5. Construction d’une image OpenWrt
 ```bash
 cd imagebuilder
 ./build.sh --release 24.10.0 --target ramips --subtarget mt7621 --profile xiaomi_mi-router-4a-gigabit
 ```
 
 ## 6. Inventaire et variables
-
 ```ini
 # inventories/production/hosts.ini
 [openwrt]
@@ -60,24 +53,19 @@ router1 ansible_host=192.168.1.1
 ```
 
 ## 7. Bootstrap initial
-
 ```bash
 ansible-playbook -i inventories/production/hosts.ini playbooks/bootstrap.yml
 ```
 
 ## 8. Déploiement GitOps
-
 ```bash
 git checkout -b feat/config-router1
 git commit -am "feat: configure router1 vlan iot"
 git push origin feat/config-router1
 ```
-
-* CI: `yamllint .`, `ansible-lint -v`, `shellcheck imagebuilder/build.sh`, `ansible-playbook --syntax-check`.
-* Post-merge: `ansible-playbook -i inventories/production/hosts.ini playbooks/site.yml` via workflow protégé.
+*CI :* `yamllint .`, `ansible-lint -v`, `shellcheck imagebuilder/build.sh`, `ansible-playbook --syntax-check`.
 
 ## 9. Rollback
-
 ```bash
 git revert <commit>
 scp backup.tgz root@routeur:/tmp/
@@ -85,7 +73,6 @@ ssh root@routeur "tar xzf /tmp/backup.tgz -C /"
 ```
 
 ## 10. Commandes utiles
-
 ```bash
 ansible-lint -v
 yamllint .
@@ -95,7 +82,6 @@ ansible-playbook -i inventories/production/hosts.ini playbooks/site.yml
 ```
 
 ## 11. Ressources
-
-* [OpenWrt](https://openwrt.org)
-* [Ansible](https://docs.ansible.com)
-* [SOPS](https://github.com/getsops/sops)
+- [OpenWrt](https://openwrt.org)
+- [Ansible](https://docs.ansible.com)
+- [SOPS](https://github.com/getsops/sops)

--- a/imagebuilder/README.md
+++ b/imagebuilder/README.md
@@ -1,9 +1,8 @@
-# ImageBuilder helper
+# ImageBuilder
 
-Ce dossier facilite la création d'images OpenWrt custom incluant les paquets utiles à Ansible (ex: `python3-light`, `openssh-sftp-server`).
+Utilitaires pour construire des images OpenWrt personnalisées contenant les paquets nécessaires à Ansible.
 
 ## Utilisation
-
 ```bash
 cd imagebuilder
 ./build.sh \
@@ -11,15 +10,12 @@ cd imagebuilder
   --target ramips \
   --subtarget mt7621 \
   --profile xiaomi_mi-router-4a-gigabit
-
-# Exemple de paquets ajoutés :
-# python3-light openssh-sftp-server ca-bundle ca-certificates
+# paquets ajoutés : python3-light openssh-sftp-server ca-bundle ca-certificates
 ```
+> Vérifier sur openwrt.org la combinaison `release/target/subtarget/profile` correspondant au matériel.
 
-> ⚠️ Vérifie sur openwrt.org la combinaison `release/target/subtarget/profile` propre à ton matériel.
+Personnalisation :
+- **PACKAGES** : liste de paquets supplémentaires.
+- **files/** : overlay (bannières, `uci-defaults`, clés SSH…).
 
-Tu peux personnaliser :
-- `PACKAGES` : liste d'addons.
-- `files/` : overlay (bannières, uci-defaults, clés SSH…).
-
-Le script télécharge et extrait temporairement l'ImageBuilder puis supprime automatiquement l'archive et le dossier à la fin de l'exécution (ou en cas d'erreur). Les images générées sont conservées dans `imagebuilder/bin/targets/...`.
+Le script télécharge l’ImageBuilder, exécute la compilation puis supprime les fichiers temporaires. Les images générées sont stockées dans `imagebuilder/bin/targets/...`.

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -1,13 +1,14 @@
 # Rôle backup
 
-Automatise la sauvegarde de la configuration OpenWrt via un script cron.
+## Objectif
+Automatise la sauvegarde de la configuration OpenWrt via cron.
 
 ## Variables
-- `backup_enabled` (booléen) : active la sauvegarde. Valeur par défaut : `true`.
-- `backup_destination` (chaîne) : destination `scp`/`rsync` des sauvegardes.
-- `backup_schedule` (chaîne) : expression cron définissant la planification.
+- `backup_enabled` (bool) : active la sauvegarde (`true` par défaut)
+- `backup_destination` (string) : destination `scp` ou `rsync`
+- `backup_schedule` (string) : expression cron de planification
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/base/README.md
+++ b/roles/base/README.md
@@ -1,15 +1,16 @@
 # Rôle base
 
-Configure les paramètres système de base : nom d'hôte, fuseau horaire et clés SSH.
+## Objectif
+Configure les paramètres système essentiels : nom d’hôte, fuseau horaire et clés SSH.
 
 ## Variables
-- `base_system.hostname` : nom d'hôte (défaut : `openwrt`).
-- `base_system.timezone` : fuseau horaire (défaut : `UTC`).
-- `base_system.zonename` : zone OpenWrt (défaut : `UTC`).
-- `base_system.ntp_servers` : liste des serveurs NTP.
-- `base_system.authorized_keys` : clés publiques autorisées pour SSH.
+- `base_system.hostname` (string) : nom d’hôte (`openwrt` par défaut)
+- `base_system.timezone` (string) : fuseau horaire (`UTC` par défaut)
+- `base_system.zonename` (string) : zone OpenWrt (`UTC` par défaut)
+- `base_system.ntp_servers` (list) : serveurs NTP
+- `base_system.authorized_keys` (list) : clés publiques autorisées
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/dnsdhcp/README.md
+++ b/roles/dnsdhcp/README.md
@@ -1,13 +1,14 @@
 # Rôle dnsdhcp
 
-Gère les services DNS et DHCP via `dnsmasq` et la configuration réseau de base.
+## Objectif
+Configure les services DNS et DHCP via `dnsmasq`.
 
 ## Variables
-- `dnsdhcp_config` : paramètres DHCP (plage, domaine…).
-- `dnsdhcp_network` : interfaces LAN/WAN et ponts.
-- `dnsdhcp_vlans` : définition des VLANs (optionnel).
+- `dnsdhcp_config` (dict) : paramètres DHCP
+- `dnsdhcp_network` (dict) : interfaces LAN/WAN
+- `dnsdhcp_vlans` (dict) : VLANs (optionnel)
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/fail2ban/README.md
+++ b/roles/fail2ban/README.md
@@ -1,12 +1,13 @@
 # Rôle fail2ban
 
+## Objectif
 Installe et configure `fail2ban` pour protéger les services exposés.
 
 ## Variables
-- `fail2ban_enabled` : active le service (défaut : `true`).
-- `fail2ban_jails` : liste des *jails* à appliquer.
+- `fail2ban_enabled` (bool) : active le service (`true` par défaut)
+- `fail2ban_jails` (list) : jails à appliquer
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -1,12 +1,13 @@
 # Rôle firewall
 
-Déploie la configuration `fw4` du pare-feu OpenWrt, incluant VLANs et WireGuard.
+## Objectif
+Déploie la configuration `fw4` du pare‑feu OpenWrt, VLANs et WireGuard inclus.
 
 ## Variables
-- `firewall_wireguard` : interfaces WireGuard à autoriser.
-- `firewall_vlans` : règles spécifiques pour les VLANs.
+- `firewall_wireguard` (dict) : interfaces WireGuard à autoriser
+- `firewall_vlans` (dict) : règles spécifiques pour les VLANs
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/ha/README.md
+++ b/roles/ha/README.md
@@ -1,12 +1,13 @@
 # Rôle ha
 
+## Objectif
 Met en place la haute disponibilité avec `keepalived` et VRRP.
 
 ## Variables
-- `ha_enabled` : active la fonctionnalité (défaut : `false`).
-- `ha_vrrp_instances` : définition des instances VRRP.
+- `ha_enabled` (bool) : active la fonctionnalité (`false` par défaut)
+- `ha_vrrp_instances` (list) : instances VRRP à configurer
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/ids/README.md
+++ b/roles/ids/README.md
@@ -1,12 +1,13 @@
 # Rôle ids
 
-Déploie le système de détection d'intrusion Suricata.
+## Objectif
+Déploie le système de détection d’intrusion Suricata.
 
 ## Variables
-- `ids_enabled` : active l'installation (défaut : `false`).
-- `ids_interface` : interface réseau à surveiller (défaut : `br-lan`).
+- `ids_enabled` (bool) : active l'installation (`false` par défaut)
+- `ids_interface` (string) : interface réseau surveillée (`br-lan` par défaut)
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/logging/README.md
+++ b/roles/logging/README.md
@@ -1,13 +1,14 @@
 # Rôle logging
 
-Configure l'envoi des logs système vers un serveur `rsyslog` centralisé.
+## Objectif
+Redirige les journaux système vers un serveur `rsyslog` centralisé.
 
 ## Variables
-- `logging_enabled` : active la redirection (défaut : `false`).
-- `logging_server` : adresse du serveur de logs.
-- `logging_facility` : facilités à transférer.
+- `logging_enabled` (bool) : active la redirection (`false` par défaut)
+- `logging_server` (string) : adresse du serveur
+- `logging_facility` (string) : facilités à transférer
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:
@@ -15,4 +16,5 @@ Configure l'envoi des logs système vers un serveur `rsyslog` centralisé.
       vars:
         logging_enabled: true
         logging_server: log.example.com
+        logging_facility: '*'
 ```

--- a/roles/monitoring/README.md
+++ b/roles/monitoring/README.md
@@ -1,12 +1,13 @@
 # Rôle monitoring
 
-Installe `collectd` pour collecter des métriques système.
+## Objectif
+Déploie `collectd` pour collecter des métriques système.
 
 ## Variables
-- `monitoring_enabled` : active la collecte (défaut : `true`).
-- `monitoring_plugins` : plugins collectd à activer.
+- `monitoring_enabled` (bool) : active la collecte (`true` par défaut)
+- `monitoring_plugins` (list) : plugins `collectd` à activer
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/network/README.md
+++ b/roles/network/README.md
@@ -1,13 +1,14 @@
 # Rôle network
 
-Gère la configuration des interfaces réseau, VLANs et tunnels WireGuard.
+## Objectif
+Gère les interfaces réseau, VLANs et tunnels WireGuard.
 
 ## Variables
-- `network_config` : définition des interfaces LAN/WAN et des ponts.
-- `network_wireguard` : interfaces WireGuard à créer.
-- `network_vlans` : configuration des VLANs (optionnel).
+- `network_config` (dict) : interfaces LAN/WAN et ponts
+- `network_wireguard` (dict) : interfaces WireGuard
+- `network_vlans` (dict) : définition des VLANs
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/ntp/README.md
+++ b/roles/ntp/README.md
@@ -1,12 +1,13 @@
 # Rôle ntp
 
-Installe et configure le démon NTP pour la synchronisation horaire.
+## Objectif
+Installe et configure le service NTP pour synchroniser l’horloge.
 
 ## Variables
-- `ntp_enabled` : active le service (défaut : `true`).
-- `ntp_servers` : liste des serveurs NTP à contacter.
+- `ntp_enabled` (bool) : active le service (`true` par défaut)
+- `ntp_servers` (list) : serveurs NTP à contacter
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/packages/README.md
+++ b/roles/packages/README.md
@@ -1,11 +1,12 @@
 # Rôle packages
 
+## Objectif
 Installe des paquets supplémentaires via `opkg`.
 
 ## Variables
-- `packages_opkg_packages` : liste des paquets à installer.
+- `packages_opkg_packages` (list) : paquets à installer
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/routing/README.md
+++ b/roles/routing/README.md
@@ -1,13 +1,15 @@
 # Rôle routing
 
+## Objectif
 Active le routage dynamique avec `bird2`.
 
 ## Variables
-- `routing_enabled` : active le rôle (défaut : `false`).
-- `routing_protocol` : protocole utilisé (défaut : `bird2`).
-- `routing_config` : configuration BIRD à appliquer.
+- `routing_enabled` (bool) : active le rôle (`false` par défaut)
+- `routing_protocol` (string) : protocole utilisé (`bird2` par défaut)
+- `routing_config` (string) : configuration BIRD
+- `routing_interfaces` (list) : interfaces additionnelles
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:

--- a/roles/wireless/README.md
+++ b/roles/wireless/README.md
@@ -1,15 +1,16 @@
 # Rôle wireless
 
-Configure le Wi-Fi (SSID, clé, pays) sur les interfaces radio.
+## Objectif
+Configure les interfaces Wi-Fi (SSID, clé, pays).
 
 ## Variables
-- `wireless_config.enabled` : active le Wi-Fi (défaut : `false`).
-- `wireless_config.country` : code pays.
-- `wireless_config.ssid` : nom du réseau.
-- `wireless_config.encryption` : type de chiffrement.
-- `wireless_config.key` : clé pré-partagée.
+- `wireless_config.enabled` (bool) : active le Wi-Fi (`false` par défaut)
+- `wireless_config.country` (string) : code pays
+- `wireless_config.ssid` (string) : nom du réseau
+- `wireless_config.encryption` (string) : méthode de chiffrement
+- `wireless_config.key` (string) : clé pré-partagée
 
-## Utilisation
+## Exemple
 ```yaml
 - hosts: routeurs
   roles:


### PR DESCRIPTION
## Summary
- rewrite and unify README files across repository
- document deployment process and examples in French
- standardize role documentation structure

## Testing
- `yamllint .`
- `ansible-lint`
- `ansible-playbook -i inventories/production/hosts.ini --syntax-check playbooks/site.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c574b4de40832b858a6fb581e6eef5