### PR TITLE
feat: add SOPS configuration and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.swp
 *.swo
 *.DS_Store
+
+# SOPS decrypted files
+group_vars/*.secrets.yml

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ pre-commit run --all-files
 
 Les hooks sont également exécutés dans la CI.
 
+## Gestion des secrets
+Ce dépôt utilise [SOPS](https://github.com/getsops/sops) avec des clés [age](https://age-encryption.org/) pour chiffrer les variables sensibles.
+
+Pour éditer un fichier chiffré :
+```bash
+sops group_vars/example.sops.yml
+```
+
+Le fichier déchiffré `group_vars/*.secrets.yml` est ignoré par Git.
+
+
 ## Inventaires
 Trois environnements sont fournis :
 

--- a/docs/adr/0001-sops-age.md
+++ b/docs/adr/0001-sops-age.md
@@ -1,0 +1,14 @@
+# ADR 0001 - Gestion des secrets avec SOPS et age
+
+date: 2025-09-13
+
+## Contexte
+Les variables sensibles doivent être chiffrées pour respecter l'approche GitOps.
+
+## Décision
+Utiliser [SOPS](https://github.com/getsops/sops) avec une clé publique [age](https://age-encryption.org/) pour chiffrer les fichiers `group_vars/*.sops.yml`. Les fichiers déchiffrés `group_vars/*.secrets.yml` sont ignorés par Git.
+
+## Conséquences
+- Édition sécurisée des secrets via `sops`.
+- Distribution de la clé privée age aux opérateurs autorisés.
+- Nécessité de conserver `sops.yaml` à jour en cas de rotation de clé.

--- a/sops.yaml
+++ b/sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: group_vars/[^/]+\.sops\.yml
+    age: "age1vp9zy2n96x7ecm3ytst33ztmnd8y7eyle3932v3l7trxxkvxk5aqlxudmm"


### PR DESCRIPTION
## Summary
- configure SOPS to use age for group vars
- ignore decrypted secrets files
- document SOPS usage and add ADR

## Testing
- `pre-commit run --files sops.yaml .gitignore README.md docs/adr/0001-sops-age.md` *(fails: missing Ansible community.general collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c58b20b534832b92001b3f28925047