### PR TITLE
ci: add Molecule tests for base role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
             pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint \
-              pre-commit
+              pre-commit 'molecule[docker]'
           ansible --version
           ansible-lint --version
           yamllint --version
@@ -47,6 +47,11 @@ jobs:
       - name: Lint playbooks/roles
         run: |
           ansible-lint -v
+
+      - name: Molecule test base role
+        run: |
+          cd roles/base
+          molecule test
 
       - name: Syntax-check playbooks (production inventory)
         run: |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ pre-commit run --all-files
 
 Les hooks sont également exécutés dans la CI.
 
+### Tests des rôles avec Molecule
+
+Ce projet utilise [Molecule](https://molecule.readthedocs.io/) pour tester les rôles Ansible.
+Un scénario est disponible pour le rôle `base`.
+
+```bash
+pip install "molecule[docker]"
+cd roles/base
+molecule test
+```
+
+Les tests sont exécutés automatiquement dans la CI pour chaque pull request.
+
 ## Gestion des secrets
 Ce dépôt utilise [SOPS](https://github.com/getsops/sops) avec des clés [age](https://age-encryption.org/) pour chiffrer les variables sensibles.
 

--- a/docs/adr/0002-molecule.md
+++ b/docs/adr/0002-molecule.md
@@ -1,0 +1,14 @@
+# ADR 0002 - Tests des rôles avec Molecule
+
+date: 2024-05-21
+
+## Contexte
+La validation automatique des rôles est nécessaire pour garantir leur bon fonctionnement et faciliter les contributions.
+
+## Décision
+Adopter [Molecule](https://molecule.readthedocs.io/) avec le pilote Docker pour tester les rôles Ansible. Un scénario initial est ajouté pour le rôle `base` et intégré à la CI.
+
+## Conséquences
+- Dépendance supplémentaire `molecule[docker]`.
+- Exécution de `molecule test` dans la CI sur chaque pull request.
+- Les contributeurs peuvent vérifier les rôles localement avant soumission.

--- a/roles/base/molecule/default/converge.yml
+++ b/roles/base/molecule/default/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Ensure /etc/config exists
+      ansible.builtin.file:
+        path: /etc/config
+        state: directory
+        mode: '0755'
+    - name: Provide dummy uci command
+      ansible.builtin.copy:
+        dest: /usr/bin/uci
+        mode: '0755'
+        content: |
+          #!/bin/sh
+          exit 0
+  roles:
+    - role: base

--- a/roles/base/molecule/default/molecule.yml
+++ b/roles/base/molecule/default/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: debian:12
+    command: /usr/bin/sleep infinity
+    pre_build_image: true
+
+provisioner:
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint
+
+verifier:
+  name: ansible


### PR DESCRIPTION
## Summary
- add Molecule scenario for base role
- run `molecule test` in CI
- document Molecule usage and record ADR

## Testing
- `pre-commit run --files roles/base/molecule/default/molecule.yml roles/base/molecule/default/converge.yml .github/workflows/ci.yml README.md docs/adr/0002-molecule.md` *(failed: couldn't resolve module community.general.opkg)*
- `ansible-galaxy collection install -r requirements.yml` *(failed: 403 Forbidden)*
- `cd roles/base && molecule test` *(failed: Failed to find driver docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f5fe8f4832bbff38b89fcd2ce18