### PR TITLE
ci: run molecule tests in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
             pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint \
-              pre-commit
+              pre-commit molecule molecule-plugins
           ansible --version
           ansible-lint --version
           yamllint --version
+          molecule --version
           pre-commit --version
 
       - name: Install Ansible collections
@@ -47,6 +48,14 @@ jobs:
       - name: Lint playbooks/roles
         run: |
           ansible-lint -v
+
+      - name: Run Molecule tests
+        run: |
+          for role in roles/*; do
+            if [ -d "$role/molecule" ]; then
+              (cd "$role" && molecule test)
+            fi
+          done
 
       - name: Syntax-check playbooks (production inventory)
         run: |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Ce dépôt fournit une collection de rôles Ansible et de playbooks pour gérer 
 ## Développement
 Ce dépôt utilise [pre-commit](https://pre-commit.com) pour exécuter les linters
 (`yamllint`, `ansible-lint`, `shellcheck`) et vérifier le style des fichiers.
+Des scénarios [Molecule](https://molecule.readthedocs.io) permettent de tester les rôles
+Ansible localement et sont exécutés dans la CI.
 Pour préparer l'environnement local :
 
 ```bash
@@ -40,7 +42,14 @@ pre-commit install
 pre-commit run --all-files
 ```
 
-Les hooks sont également exécutés dans la CI.
+Pour lancer les tests Molecule d'un rôle (ex. `base`) :
+
+```bash
+pip install molecule molecule-plugins
+cd roles/base && molecule test
+```
+
+Les hooks et tests sont également exécutés dans la CI.
 
 ## Gestion des secrets
 Ce dépôt utilise [SOPS](https://github.com/getsops/sops) avec des clés [age](https://age-encryption.org/) pour chiffrer les variables sensibles.

--- a/roles/base/meta/main.yml
+++ b/roles/base/meta/main.yml
@@ -4,4 +4,6 @@ galaxy_info:
   description: Base system configuration
   license: MIT
   min_ansible_version: '2.14'
+  role_name: base
+  namespace: openwrt
 dependencies: []

--- a/roles/base/molecule/default/molecule.yml
+++ b/roles/base/molecule/default/molecule.yml
@@ -3,12 +3,17 @@ dependency:
   name: shell
   command: /bin/true
 driver:
-  name: delegated
+  name: default
 platforms:
   - name: instance
 provisioner:
   name: ansible
   env:
-    ANSIBLE_ROLES_PATH: ../..
+    ANSIBLE_ROLES_PATH: ../../..
+  inventory:
+    host_vars:
+      instance:
+        ansible_connection: local
+        ansible_python_interpreter: /usr/bin/python3
 verifier:
   name: ansible


### PR DESCRIPTION
## Summary
- install molecule and run tests for roles in CI
- document Molecule usage
- add role metadata for Molecule

## Testing
- `ansible-galaxy collection install -r requirements.yml` *(fails: 403 Forbidden)*
- `pre-commit run --all-files` *(fails: unknown module community.general.opkg)*
- `cd roles/base && molecule test` *(fails: driver delegated not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59c138a80832ba1997cd814b3611b