### PR TITLE
feat: add trivy security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,15 @@ jobs:
             playbooks/bootstrap.yml
           ansible-playbook -i inventories/production/hosts.ini --syntax-check \
             playbooks/site.yml
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          exit-code: '1'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,18 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+  - repo: local
+    hooks:
+      - id: trivy
+        name: trivy fs scan
+        entry: trivy fs
+        language: system
+        types: [file]
+        pass_filenames: false
+        args:
+          - "--severity"
+          - "HIGH,CRITICAL"
+          - "--ignore-unfixed"
+          - "--exit-code"
+          - "1"
+          - "."

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ cd roles/base && molecule test
 
 Les hooks et tests sont également exécutés dans la CI.
 
+### Scan de sécurité
+
+Ce dépôt utilise [Trivy](https://github.com/aquasecurity/trivy) pour analyser les dépendances et configurations.
+Le hook pre-commit `trivy` et le job CI `security-scan` échouent si des vulnérabilités de sévérité `HIGH` ou `CRITICAL` sont détectées.
+Les vulnérabilités non corrigées sont ignorées via l'option `--ignore-unfixed`.
+
 ## Gestion des secrets
 Ce dépôt utilise [SOPS](https://github.com/getsops/sops) avec des clés [age](https://age-encryption.org/) pour chiffrer les variables sensibles.
 

--- a/docs/adr/0002-trivy-security-scan.md
+++ b/docs/adr/0002-trivy-security-scan.md
@@ -1,0 +1,15 @@
+# ADR 0002 - Analyse de sécurité avec Trivy
+
+date: 2025-09-13
+
+## Contexte
+Pour garantir la qualité des infrastructures gérées via Ansible, il est nécessaire de détecter les vulnérabilités dans les dépendances et configurations.
+
+## Décision
+Utiliser [Trivy](https://github.com/aquasecurity/trivy) pour scanner le dépôt. Les scans sont exécutés localement via un hook pre-commit et dans la CI avec `aquasecurity/trivy-action`.
+Le seuil de sévérité est fixé à `HIGH,CRITICAL` et les vulnérabilités non corrigées sont ignorées (`--ignore-unfixed`).
+
+## Conséquences
+- Visibilité précoce sur les failles de sécurité.
+- Échecs de commit ou de pipeline si des vulnérabilités critiques sont détectées.
+- Possibilité d'ajuster la politique en modifiant `.pre-commit-config.yaml` et le workflow CI.

--- a/sops.yaml
+++ b/sops.yaml
@@ -1,3 +1,4 @@
+---
 creation_rules:
   - path_regex: group_vars/[^/]+\.sops\.yml
     age: "age1vp9zy2n96x7ecm3ytst33ztmnd8y7eyle3932v3l7trxxkvxk5aqlxudmm"


### PR DESCRIPTION
## Summary
- add Trivy hook to pre-commit
- run Trivy in new `security-scan` workflow job
- document vulnerability scanning policy via README and ADR

## Testing
- `pre-commit run --all-files` *(fails: syntax-check[unknown-module]: couldn't resolve module/action 'community.general.opkg')*
- `ansible-galaxy collection install -r requirements.yml` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a0c863a0832b8104b7d3f78fff58