### PR TITLE
ci: add Trivy security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: fs
+          security-checks: vuln,config,secret
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+
       - name: Yamllint repository
         run: yamllint .
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ cd roles/base && molecule test
 
 Les hooks et tests sont également exécutés dans la CI.
 
+La sécurité est contrôlée via [Trivy](https://github.com/aquasecurity/trivy) qui analyse le dépôt pour détecter vulnérabilités, erreurs de configuration et secrets. Un scan local peut être lancé avec :
+
+```bash
+trivy fs .
+```
+
 ## Gestion des secrets
 Ce dépôt utilise [SOPS](https://github.com/getsops/sops) avec des clés [age](https://age-encryption.org/) pour chiffrer les variables sensibles.
 

--- a/docs/adr/0002-trivy-security-scan.md
+++ b/docs/adr/0002-trivy-security-scan.md
@@ -1,0 +1,14 @@
+# ADR 0002 - Intégration de Trivy pour l'analyse de sécurité
+
+date: 2025-09-14
+
+## Contexte
+Afin de renforcer la sécurité dans l'approche GitOps, il est nécessaire d'analyser automatiquement le dépôt pour détecter les vulnérabilités, les erreurs de configuration et les secrets accidentellement commis.
+
+## Décision
+Utiliser [Trivy](https://github.com/aquasecurity/trivy) pour scanner le dépôt dans la CI.
+
+## Conséquences
+- Un scan Trivy est exécuté à chaque pipeline GitHub Actions.
+- Les développeurs peuvent lancer `trivy fs .` localement pour vérifier leurs changements.
+- La version de Trivy utilisée dans le pipeline doit être maintenue à jour.


### PR DESCRIPTION
## Summary
- scan repository with Trivy in CI
- document Trivy usage
- record decision in ADR

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md docs/adr/0002-trivy-security-scan.md` *(fails: couldn't resolve module 'community.general.opkg')*

------
https://chatgpt.com/codex/tasks/task_e_68c5ac035ebc832b823cd99ae3a4fbb5