### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ La sécurité est contrôlée via [Trivy](https://github.com/aquasecurity/trivy)
 trivy fs .
 ```
 
+Les dépendances des workflows sont automatiquement mises à jour par [Dependabot](https://docs.github.com/fr/code-security/dependabot).
+
 ## Gestion des secrets
 Ce dépôt utilise [SOPS](https://github.com/getsops/sops) avec des clés [age](https://age-encryption.org/) pour chiffrer les variables sensibles.
 

--- a/docs/adr/0003-dependabot.md
+++ b/docs/adr/0003-dependabot.md
@@ -1,0 +1,14 @@
+# ADR 0003 - Automatisation des mises à jour avec Dependabot
+
+date: 2025-09-15
+
+## Contexte
+Les dépendances des workflows et outils peuvent rapidement devenir obsolètes et comporter des vulnérabilités.
+
+## Décision
+Activer [Dependabot](https://docs.github.com/fr/code-security/dependabot) pour vérifier et proposer automatiquement les mises à jour des actions GitHub.
+
+## Conséquences
+- Un fichier `.github/dependabot.yml` configure une vérification hebdomadaire.
+- Des Pull Requests automatiques seront ouvertes pour maintenir les actions à jour.
+- Les mainteneurs doivent examiner et fusionner ces mises à jour.


### PR DESCRIPTION
## Summary
- configure Dependabot for GitHub Actions
- document Dependabot usage and record ADR

## Testing
- `pre-commit run --all-files` *(fails: couldn't resolve module `community.general.opkg` during ansible-lint; collection download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5aee5485c832bb2ffa864d7416dc1