### PR TITLE
chore(ci): add commitlint configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Commitlint
+        uses: wagoid/commitlint-github-action@v5
 
       - name: Install ShellCheck
         run: |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Ce dépôt utilise [pre-commit](https://pre-commit.com) pour exécuter les linte
 (`yamllint`, `ansible-lint`, `shellcheck`) et vérifier le style des fichiers.
 Des scénarios [Molecule](https://molecule.readthedocs.io) permettent de tester les rôles
 Ansible localement et sont exécutés dans la CI.
+Les messages de commit doivent suivre la convention [Conventional Commits](https://www.conventionalcommits.org)
+et sont vérifiés via [commitlint](https://commitlint.js.org) (`commitlint.config.js`).
 Pour préparer l'environnement local :
 
 ```bash

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};


### PR DESCRIPTION
## Summary
- add commitlint config using conventional commits
- run commitlint in CI and document requirement

## Testing
- `pre-commit run --all-files` *(fails: couldn't resolve module/action 'community.general.opkg')*


------
https://chatgpt.com/codex/tasks/task_e_68c5b535137c832b9cfe47511d85c4c7