### PR TITLE
ci: cache dependencies for faster workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.yml', '.pre-commit-config.yaml') }}
+          key: >-
+            ${{ runner.os }}-pip-${{ hashFiles(
+              'requirements.yml', '.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 
@@ -39,7 +41,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.ansible
-          key: ${{ runner.os }}-ansible-${{ hashFiles('requirements.yml', '.pre-commit-config.yaml') }}
+          key: >-
+            ${{ runner.os }}-ansible-${{ hashFiles(
+              'requirements.yml', '.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ runner.os }}-ansible-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.yml', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache Ansible collections
+        uses: actions/cache@v4
+        with:
+          path: ~/.ansible
+          key: ${{ runner.os }}-ansible-${{ hashFiles('requirements.yml', '.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-ansible-
+
       - name: Install Ansible + linters + pre-commit
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ cd roles/base && molecule test
 
 Les hooks et tests sont également exécutés dans la CI.
 
+Le pipeline GitHub Actions met en cache `~/.cache/pip` et `~/.ansible` en fonction de
+`requirements.yml` et `.pre-commit-config.yaml` afin de réduire les téléchargements
+sur les exécutions ultérieures.
+
 La sécurité est contrôlée via [Trivy](https://github.com/aquasecurity/trivy) qui analyse le dépôt pour détecter vulnérabilités, erreurs de configuration et secrets. Un scan local peut être lancé avec :
 
 ```bash


### PR DESCRIPTION
## Summary
- cache pip and Ansible directories in workflow to speed up runs
- document caching in README

## Testing
- `pre-commit run --all-files` *(fails: community.general.opkg missing)*
- `act -n` *(fails: no Docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b6e0a2d0832b8f11eef7b93ecbae