### PR TITLE
feat: add make targets and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,8 @@ jobs:
 
       - name: Install Ansible collections
         run: ansible-galaxy collection install -r requirements.yml
-
-      - name: Run pre-commit
-        run: pre-commit run --all-files
+      - name: Run lint
+        run: make lint
 
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@0.33.1
@@ -73,24 +72,5 @@ jobs:
           ignore-unfixed: true
           severity: CRITICAL,HIGH
 
-      - name: Yamllint repository
-        run: yamllint .
-
-      - name: Lint playbooks/roles
-        run: |
-          ansible-lint -v
-
-      - name: Run Molecule tests
-        run: |
-          for role in roles/*; do
-            if [ -d "$role/molecule" ]; then
-              (cd "$role" && molecule test)
-            fi
-          done
-
-      - name: Syntax-check playbooks (production inventory)
-        run: |
-          ansible-playbook -i inventories/production/hosts.ini --syntax-check \
-            playbooks/bootstrap.yml
-          ansible-playbook -i inventories/production/hosts.ini --syntax-check \
-            playbooks/site.yml
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.RECIPEPREFIX := >
+SHELL := /bin/bash
+
+.PHONY: install lint test scan
+
+install:
+>python -m pip install --upgrade pip
+>pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint pre-commit molecule molecule-plugins
+>ansible-galaxy collection install -r requirements.yml
+>curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+lint:
+>pre-commit run --all-files
+
+test:
+>./scripts/test.sh
+
+scan:
+>trivy fs --exit-code 1 --security-checks vuln,config,secret --ignore-unfixed --severity CRITICAL,HIGH .

--- a/README.md
+++ b/README.md
@@ -36,32 +36,39 @@ Des scénarios [Molecule](https://molecule.readthedocs.io) permettent de tester 
 Ansible localement et sont exécutés dans la CI.
 Les messages de commit doivent suivre la convention [Conventional Commits](https://www.conventionalcommits.org)
 et sont vérifiés via [commitlint](https://commitlint.js.org) (`commitlint.config.js`).
-Pour préparer l'environnement local :
+
+### Commandes Make
+
+Préparer l'environnement local :
 
 ```bash
-pip install pre-commit
-pre-commit install
-pre-commit run --all-files
+make install
 ```
 
-Pour lancer les tests Molecule d'un rôle (ex. `base`) :
+Exécuter les linters :
 
 ```bash
-pip install molecule molecule-plugins
-cd roles/base && molecule test
+make lint
+```
+
+Lancer les tests Molecule et la vérification de syntaxe :
+
+```bash
+make test
+```
+
+Scanner le dépôt :
+
+```bash
+make scan
 ```
 
 Les hooks et tests sont également exécutés dans la CI.
-
 Le pipeline GitHub Actions met en cache `~/.cache/pip` et `~/.ansible` en fonction de
 `requirements.yml` et `.pre-commit-config.yaml` afin de réduire les téléchargements
 sur les exécutions ultérieures.
 
-La sécurité est contrôlée via [Trivy](https://github.com/aquasecurity/trivy) qui analyse le dépôt pour détecter vulnérabilités, erreurs de configuration et secrets. Un scan local peut être lancé avec :
-
-```bash
-trivy fs .
-```
+La sécurité est contrôlée via [Trivy](https://github.com/aquasecurity/trivy) qui analyse le dépôt pour détecter vulnérabilités, erreurs de configuration et secrets. Un scan local peut être lancé avec `make scan`.
 
 Les dépendances des workflows sont automatiquement mises à jour par [Dependabot](https://docs.github.com/fr/code-security/dependabot).
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+for role in roles/*; do
+  if [ -d "$role/molecule" ]; then
+    (cd "$role" && molecule test)
+  fi
+done
+ansible-playbook -i inventories/production/hosts.ini --syntax-check playbooks/bootstrap.yml
+ansible-playbook -i inventories/production/hosts.ini --syntax-check playbooks/site.yml


### PR DESCRIPTION
## Summary
- add Makefile with install, lint, test and scan targets
- simplify CI by invoking `make lint` and `make test`
- document Makefile workflow in README

## Testing
- `make lint` *(fails: missing community.general collection)*
- `make test` *(fails: missing community.general.opkg module)*
- `make scan`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb427edc832bbd790cbe7e6dd15f