### PR TITLE
chore(dev): enforce commit message lint locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.9.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ install:
 >pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint pre-commit molecule molecule-plugins
 >ansible-galaxy collection install -r requirements.yml
 >curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+>pre-commit install --install-hooks -t pre-commit -t commit-msg
 
 lint:
 >pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ Des scénarios [Molecule](https://molecule.readthedocs.io) permettent de tester 
 Ansible localement et sont exécutés dans la CI.
 Les messages de commit doivent suivre la convention [Conventional Commits](https://www.conventionalcommits.org)
 et sont vérifiés via [commitlint](https://commitlint.js.org) (`commitlint.config.js`).
+Le hook `commit-msg` fourni par `pre-commit` applique cette vérification localement ;
+`make install` installe automatiquement les hooks nécessaires.
 
 ### Commandes Make
 
-Préparer l'environnement local :
+Préparer l'environnement local et installer les hooks `pre-commit` :
 
 ```bash
 make install


### PR DESCRIPTION
## Summary
- enforce commitlint locally via pre-commit commit-msg hook
- auto-install pre-commit hooks in Makefile
- document commit message linting

## Testing
- [ ] `make lint`
- [ ] `make test`
- [ ] `make scan`


------
https://chatgpt.com/codex/tasks/task_e_68c5b4ca7344832ba269c76b81f367fb