### PR TITLE
feat(mptcp): add Multipath TCP role

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ imagebuilder/               # génération d’images personnalisées
 - [network](roles/network/README.md) : interfaces, VLANs, WireGuard
 - [dnsdhcp](roles/dnsdhcp/README.md) : service DNS/DHCP
 - [routing](roles/routing/README.md) : routage dynamique Bird2
+- [mptcp](roles/mptcp/README.md) : support Multipath TCP
 - [wireless](roles/wireless/README.md) : configuration Wi-Fi
 - [firewall](roles/firewall/README.md) : règles pare-feu supplémentaires
 - [monitoring](roles/monitoring/README.md) : métriques collectd

--- a/docs/adr/0004-mptcp-support.md
+++ b/docs/adr/0004-mptcp-support.md
@@ -1,0 +1,14 @@
+# ADR 0004 - Support Multipath TCP
+
+date: 2025-09-16
+
+## Contexte
+Certaines applications bénéficient de connexions TCP multipath pour la redondance et l'agrégation de bande passante.
+
+## Décision
+Ajouter un rôle Ansible `mptcp` installant `kmod-mptcp` et `mptcpd`, activant `net.mptcp.enabled` et démarrant le service.
+
+## Conséquences
+- Possibilité d'activer MPTCP via la variable `mptcp_config`.
+- Augmentation légère de la consommation mémoire.
+- Nécessité de surveiller la compatibilité des paquets avec MPTCP.

--- a/group_vars/openwrt.yml
+++ b/group_vars/openwrt.yml
@@ -21,6 +21,9 @@ packages_opkg_packages:
   - bird2
   - keepalived
 
+mptcp_config:
+  enabled: true
+
 network_config: &network_defaults
   lan:
     ip: 192.168.10.1

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -5,6 +5,7 @@
   roles:
     - base
     - packages
+    - mptcp
     - ntp
     - monitoring
     - logging

--- a/roles/mptcp/README.md
+++ b/roles/mptcp/README.md
@@ -1,0 +1,17 @@
+# Rôle mptcp
+
+## Objectif
+Active le support Multipath TCP et démarre le service `mptcpd`.
+
+## Variables
+- `mptcp_config` (dict) : configuration du rôle, clé `enabled` pour activer le support.
+
+## Exemple
+```yaml
+- hosts: routeurs
+  roles:
+    - role: mptcp
+      vars:
+        mptcp_config:
+          enabled: true
+```

--- a/roles/mptcp/defaults/main.yml
+++ b/roles/mptcp/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+mptcp_config:
+  enabled: false

--- a/roles/mptcp/meta/main.yml
+++ b/roles/mptcp/meta/main.yml
@@ -1,0 +1,7 @@
+---
+galaxy_info:
+  author: Franck Laplagne
+  description: Enable Multipath TCP support
+  license: MIT
+  min_ansible_version: '2.14'
+dependencies: []

--- a/roles/mptcp/tasks/main.yml
+++ b/roles/mptcp/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Update opkg cache
+  ansible.builtin.command: opkg update
+  changed_when: false
+  when: mptcp_config.enabled | bool
+
+- name: Install MPTCP packages
+  community.general.opkg:
+    name:
+      - kmod-mptcp
+      - mptcpd
+    state: present
+  when: mptcp_config.enabled | bool
+
+- name: Enable Multipath TCP
+  ansible.posix.sysctl:
+    name: net.mptcp.enabled
+    value: '1'
+    sysctl_file: /etc/sysctl.conf
+    state: present
+  when: mptcp_config.enabled | bool
+
+- name: Ensure mptcpd service is enabled
+  ansible.builtin.service:
+    name: mptcpd
+    enabled: true
+    state: started
+  when: mptcp_config.enabled | bool


### PR DESCRIPTION
## Summary
- add MPTCP role installing kernel module and daemon
- expose `mptcp_config` variable and include role in site playbook
- document MPTCP support and add ADR

## Testing
- `pre-commit run --files README.md group_vars/openwrt.yml playbooks/site.yml docs/adr/0004-mptcp-support.md roles/mptcp/defaults/main.yml roles/mptcp/tasks/main.yml roles/mptcp/meta/main.yml roles/mptcp/README.md` *(fails: couldn't resolve module community.general.opkg)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c390fa3c832ba85fdc0761d5d7e5