### PR TITLE
feat: add ENV-aware deployment target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .RECIPEPREFIX := >
 SHELL := /bin/bash
 
-INVENTORY ?= inventories/production/hosts.yml
+ENV ?= production
+PLAYBOOK ?= playbooks/site.yml
+INVENTORY ?= inventories/$(ENV)/hosts.yml
 
-.PHONY: install lint test scan site bootstrap
+.PHONY: install lint test scan site bootstrap deploy
 
 install:
 >python -m pip install --upgrade pip
@@ -16,13 +18,16 @@ lint:
 >pre-commit run --all-files
 
 test:
->./scripts/test.sh
+>ENV=$(ENV) ./scripts/test.sh
 
 site:
 >ansible-playbook -i $(INVENTORY) playbooks/site.yml
 
 bootstrap:
 >ansible-playbook -i $(INVENTORY) playbooks/bootstrap.yml
+
+deploy:
+>ansible-playbook -i $(INVENTORY) $(PLAYBOOK)
 
 scan:
 >trivy fs --exit-code 1 --security-checks vuln,config,secret --ignore-unfixed --severity CRITICAL,HIGH .

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Ce dépôt fournit une collection de rôles Ansible et de playbooks pour gérer 
    cd openwrt-ansible-ci
    ansible-galaxy collection install -r requirements.yml
    ```
-2. Enregistrer la clé hôte et lancer le bootstrap :
+2. Enregistrer la clé hôte et lancer le bootstrap :
    ```bash
    ssh-keyscan -H routeur >> ~/.ssh/known_hosts
-   ansible-playbook -i inventories/production/hosts.yml playbooks/bootstrap.yml
+   make deploy PLAYBOOK=playbooks/bootstrap.yml
    ```
 3. Adapter l’inventaire et les variables :
    ```bash
    $EDITOR inventories/production/hosts.yml group_vars/openwrt.yml
    ```
-4. Appliquer la configuration :
+4. Appliquer la configuration :
    ```bash
-   ansible-playbook -i inventories/production/hosts.yml playbooks/site.yml
+   make deploy
    ```
 
 ## Développement
@@ -40,6 +40,9 @@ Le hook `commit-msg` fourni par `pre-commit` applique cette vérification locale
 `make install` installe automatiquement les hooks nécessaires.
 
 ### Commandes Make
+
+Les cibles utilisent l'inventaire déterminé par la variable `ENV` (défaut : `production`).
+`PLAYBOOK` permet de choisir le playbook à exécuter (défaut : `playbooks/site.yml`).
 
 Préparer l'environnement local et installer les hooks `pre-commit` :
 
@@ -56,19 +59,19 @@ make lint
 Lancer les tests Molecule et la vérification de syntaxe :
 
 ```bash
-make test
+make test ENV=lab
 ```
 
 Déployer la configuration :
 
 ```bash
-make site INVENTORY=inventories/production/hosts.yml
+make deploy ENV=production
 ```
 
 Bootstraper un routeur :
 
 ```bash
-make bootstrap INVENTORY=inventories/production/hosts.yml
+make deploy ENV=production PLAYBOOK=playbooks/bootstrap.yml
 ```
 
 Scanner le dépôt :
@@ -106,12 +109,12 @@ Trois environnements sont fournis :
 | `staging`   | préproduction   |
 | `production`| déploiement     |
 
-Sélectionner l’inventaire avec `-i` ou via le Makefile :
+Sélectionner l’inventaire avec `-i` ou via la variable `ENV` du Makefile :
 
 ```bash
 ansible-playbook -i inventories/lab/hosts.yml playbooks/site.yml
 # ou
-make site INVENTORY=inventories/lab/hosts.yml
+make deploy ENV=lab
 ```
 
 ## Structure du dépôt

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 set -e
+
+ENV=${ENV:-production}
+INVENTORY="inventories/${ENV}/hosts.yml"
+
 for role in roles/*; do
   if [ -d "$role/molecule" ]; then
     (cd "$role" && molecule test)
   fi
 done
-ansible-playbook -i inventories/production/hosts.yml --syntax-check playbooks/bootstrap.yml
-ansible-playbook -i inventories/production/hosts.yml --syntax-check playbooks/site.yml
+
+ansible-playbook -i "$INVENTORY" --syntax-check playbooks/bootstrap.yml
+ansible-playbook -i "$INVENTORY" --syntax-check playbooks/site.yml


### PR DESCRIPTION
## Summary
- parameterize inventory via `ENV`, `PLAYBOOK`, and `INVENTORY`
- add generic `deploy` Make target and pass `ENV` to tests
- document Makefile variables and usage

## Testing
- `python -m pre_commit run --files Makefile scripts/test.sh README.md` *(fails: Ansible collection community.general unavailable)*
- `make test ENV=production` *(fails: interrupted during Molecule scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d3ba4168832b90aff12b52bb542f