### PR TITLE
feat(network): add VxLAN defaults

### DIFF
--- a/roles/network/README.md
+++ b/roles/network/README.md
@@ -1,12 +1,13 @@
 # Rôle network
 
 ## Objectif
-Gère les interfaces réseau, VLANs et tunnels WireGuard.
+Gère les interfaces réseau, VLANs et tunnels WireGuard/VxLAN.
 
 ## Variables
 - `network_config` (dict) : interfaces LAN/WAN et ponts
 - `network_wireguard` (dict) : interfaces WireGuard
 - `network_vlans` (dict) : définition des VLANs
+- `network_vxlan` (dict) : tunnels VxLAN
 
 ## Exemple
 ```yaml

--- a/roles/network/defaults/main.yml
+++ b/roles/network/defaults/main.yml
@@ -20,3 +20,7 @@ network_wireguard:
 network_vlans:
   enabled: false
   list: []
+
+network_vxlan:
+  enabled: false
+  tunnels: []


### PR DESCRIPTION
## Summary
- add `network_vxlan` default variable with disabled flag and empty tunnels list
- document VxLAN support in network role README

## Testing
- `pre-commit run --files roles/network/defaults/main.yml roles/network/README.md` *(fails: couldn't resolve module/action 'community.general.opkg')*


------
https://chatgpt.com/codex/tasks/task_e_68c5e52b8168832bbf41c8335e474d14