### PR TITLE
feat(network): support vxlan tunnels

### DIFF
--- a/roles/network/README.md
+++ b/roles/network/README.md
@@ -7,7 +7,7 @@ Gère les interfaces réseau, VLANs et tunnels WireGuard/VxLAN.
 - `network_config` (dict) : interfaces LAN/WAN et ponts
 - `network_wireguard` (dict) : interfaces WireGuard
 - `network_vlans` (dict) : définition des VLANs
-- `network_vxlan` (dict) : tunnels VxLAN
+- `network_vxlan` (dict) : tunnels VxLAN (`enabled`, `tunnels[]` avec `name`, `id`, `local`, `remote`, `port`, `device`, `ipaddr`)
 
 ## Exemple
 ```yaml
@@ -20,4 +20,13 @@ Gère les interfaces réseau, VLANs et tunnels WireGuard/VxLAN.
           interfaces:
             - name: wg0
               address: 10.0.0.1/24
+        network_vxlan:
+          enabled: true
+          tunnels:
+            - name: vxlan10
+              id: 10
+              local: 192.0.2.1
+              remote: 192.0.2.2
+              port: 4789
+              ipaddr: 10.10.10.1/24  # optionnel
 ```

--- a/roles/network/templates/network.j2
+++ b/roles/network/templates/network.j2
@@ -60,6 +60,25 @@ config interface '{{ vlan.iface.name }}'
 {% endfor %}
 {% endif %}
 
+{% if network_vxlan.enabled and (network_vxlan.tunnels | length) > 0 %}
+{% for vx in network_vxlan.tunnels %}
+config interface '{{ vx.name }}'
+        option proto 'vxlan'
+        option id '{{ vx.id }}'
+        option local '{{ vx.local }}'
+        option remote '{{ vx.remote }}'
+{% if vx.port is defined %}
+        option port '{{ vx.port }}'
+{% endif %}
+{% if vx.device is defined %}
+        option device '{{ vx.device }}'
+{% endif %}
+{% if vx.ipaddr is defined %}
+        option ipaddr '{{ vx.ipaddr }}'
+{% endif %}
+{% endfor %}
+{% endif %}
+
 # Routing interfaces (optional)
 {% if routing_interfaces is defined and (routing_interfaces | length) > 0 %}
 {% for iface in routing_interfaces %}


### PR DESCRIPTION
## Summary
- render VXLAN tunnel interfaces when `network_vxlan.enabled`
- document VXLAN variables and example usage

## Testing
- `make lint` *(fails: pre-commit: command not found)*
- `make install` *(fails: Unknown error when attempting to call Galaxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e66abeac832b9086c97de767952e