### PR TITLE
ci: add deploy job for main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,16 @@ jobs:
 
       - name: Run tests
         run: ENV=${{ matrix.env }} make test
+
+  deploy:
+    needs: lint-and-syntax
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [lab, staging, production]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Deploy
+        run: ENV=${{ matrix.env }} make deploy

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ make scan
 
 Les hooks et tests sont également exécutés dans la CI.
 Les tests s'exécutent pour chaque inventaire (`lab`, `staging`, `production`) via une matrice d'environnement.
+Sur `main`, un job de déploiement exécute `make deploy` pour chaque environnement.
 Le pipeline GitHub Actions met en cache `~/.cache/pip` et `~/.ansible` en fonction de
 `requirements.yml` et `.pre-commit-config.yaml` afin de réduire les téléchargements
 sur les exécutions ultérieures.


### PR DESCRIPTION
## Summary
- add deploy job triggered on main pushes
- document deploy job in README

## Testing
- `pre-commit run --files .github/workflows/ci.yml README.md` (fails: missing community.general collection due to 403 fetching collections)


------
https://chatgpt.com/codex/tasks/task_e_68c5eb11faac832baf032966b8d48c7c