### PR TITLE
ci: split workflows by commit type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,38 +3,13 @@ name: Ansible CI
 
 'on':
   push:
-    paths:
-      - '.github/**'
-      - 'ansible.cfg'
-      - 'requirements.yml'
-      - '.pre-commit-config.yaml'
-      - 'commitlint.config.js'
-      - 'Makefile'
-      - 'sops.yaml'
-      - 'inventories/**'
-      - 'group_vars/**'
-      - 'playbooks/**'
-      - 'roles/**'
-      - 'imagebuilder/**'
-      - 'scripts/**'
   pull_request:
-    paths:
-      - '.github/**'
-      - 'ansible.cfg'
-      - 'requirements.yml'
-      - '.pre-commit-config.yaml'
-      - 'commitlint.config.js'
-      - 'Makefile'
-      - 'sops.yaml'
-      - 'inventories/**'
-      - 'group_vars/**'
-      - 'playbooks/**'
-      - 'roles/**'
-      - 'imagebuilder/**'
-      - 'scripts/**'
 
 jobs:
   lint-and-syntax:
+    if: >-
+      !startsWith(github.event.head_commit.message, 'docs:') &&
+      !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'docs:'))
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -108,7 +83,10 @@ jobs:
 
   deploy:
     needs: lint-and-syntax
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      !startsWith(github.event.head_commit.message, 'docs:')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,16 +3,13 @@ name: Docs CI
 
 'on':
   push:
-    paths:
-      - 'docs/**'
-      - '**/*.md'
   pull_request:
-    paths:
-      - 'docs/**'
-      - '**/*.md'
 
 jobs:
   docs:
+    if: >-
+      startsWith(github.event.head_commit.message, 'docs:') ||
+      (github.event_name == 'pull_request' && startsWith(github.event.pull_request.title, 'docs:'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ make scan
 ```
 
 Les hooks et tests sont également exécutés dans la CI.
-Les workflows sont déclenchés selon les fichiers modifiés :
-un workflow léger pour la documentation (`Docs CI`) ne lance que les vérifications
-Markdown et commitlint, tandis que le workflow principal s'active uniquement lorsque
-la configuration Ansible ou les scripts changent.
+Les workflows sont déclenchés selon le type de commit :
+un commit `docs:` active un workflow léger (`Docs CI`) limité aux vérifications
+Markdown et commitlint, tandis que les autres types déclenchent le pipeline
+principal avec linters, tests et déploiement.
 Le lint Markdown s'appuie sur `.markdownlint.yml` pour ignorer les règles de
 longueur de ligne et d'espacement dans la documentation existante.
 Les tests s'exécutent pour chaque inventaire (`lab`, `staging`, `production`)

--- a/docs/adr/0008-ci-commit-based-workflows.md
+++ b/docs/adr/0008-ci-commit-based-workflows.md
@@ -1,0 +1,14 @@
+# ADR 0008 - Sélection des workflows CI selon le type de commit
+
+date: 2025-09-14
+
+## Contexte
+Le workflow précédent (ADR 0007) séparait les pipelines en fonction des fichiers modifiés via `paths`. Cela ne permettait pas de baser la CI sur les types de commits selon la convention Conventional Commits.
+
+## Décision
+Les workflows GitHub Actions sont déclenchés pour chaque push ou pull request mais les jobs s'exécutent selon le préfixe du commit ou du titre (`docs:` pour la documentation). Un commit `docs:` n'exécute que le workflow `Docs CI`, tandis que les autres déclenchent le pipeline Ansible complet.
+
+## Conséquences
+- Simplifie la gestion : la séparation repose sur le type de commit plutôt que sur les chemins.
+- Évite l'exécution de la pipeline principale pour les modifications de documentation.
+- Nécessite le respect strict de Conventional Commits pour que le routage fonctionne.


### PR DESCRIPTION
## Summary
- route docs commits to a lightweight Docs CI workflow
- run full Ansible pipeline for non-doc commits
- document commit-based workflow routing and record decision in ADR 0008

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/docs.yml README.md docs/adr/0008-ci-commit-based-workflows.md` *(fails: community.general collection missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c60dfb1c8c832b90972b128902ebf0