### PR TITLE
ci: add per-role container tests and simplify pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,8 @@ name: Ansible CI
       - 'scripts/**'
 
 jobs:
-  lint-and-syntax:
+  lint-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        env: [lab, staging, production]
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -81,12 +78,10 @@ jobs:
       - name: Install Ansible + linters + pre-commit
         run: |
           python -m pip install --upgrade pip
-            pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint \
-              pre-commit molecule molecule-plugins
+          pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint pre-commit docker
           ansible --version
           ansible-lint --version
           yamllint --version
-          molecule --version
           pre-commit --version
 
       - name: Install Ansible collections
@@ -104,10 +99,10 @@ jobs:
           severity: CRITICAL,HIGH
 
       - name: Run tests
-        run: ENV=${{ matrix.env }} make test
+        run: ENV=lab make test
 
   deploy:
-    needs: lint-and-syntax
+    needs: lint-test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ INVENTORY ?= inventories/$(ENV)/hosts.yml
 
 install:
 >python -m pip install --upgrade pip
->pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint pre-commit molecule molecule-plugins
+>pip install "ansible-core>=2.14,<2.17" ansible-lint yamllint pre-commit docker
 >ansible-galaxy collection install -r requirements.yml
 >curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 >pre-commit install --install-hooks -t pre-commit -t commit-msg

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Toutes les modifications passent par Git et peuvent être auditées.
 
 Ce dépôt utilise [pre-commit](https://pre-commit.com) pour exécuter les linters
 (`yamllint`, `ansible-lint`, `shellcheck`) et vérifier le style des fichiers.
-Des scénarios [Molecule](https://molecule.readthedocs.io) permettent de
-tester les rôles Ansible localement et sont exécutés dans la CI.
+Chaque rôle est validé dans un conteneur OpenWrt éphémère afin de garantir son
+idempotence ; ces tests s'exécutent également dans la CI.
 Les messages de commit doivent suivre la convention
 [Conventional Commits](https://www.conventionalcommits.org) et sont vérifiés via
 [commitlint](https://commitlint.js.org) (`commitlint.config.js`).
@@ -71,14 +71,15 @@ Exécuter les linters :
 make lint
 ```
 
-Lancer les tests Molecule et la vérification de syntaxe :
+Lancer les tests de conformité des rôles et la vérification de syntaxe :
 
 ```bash
 make test ENV=lab
 ```
 
-Cette commande démarre un conteneur OpenWrt éphémère et applique les
-playbooks pour valider chaque changement de configuration.
+Cette commande exécute chaque rôle dans un conteneur OpenWrt, vérifie l'absence
+d'effet de bord puis applique les playbooks sur un conteneur global pour valider
+la configuration.
 
 Déployer la configuration :
 
@@ -99,15 +100,12 @@ make scan
 ```
 
 Les hooks et tests sont également exécutés dans la CI.
-Les workflows sont déclenchés selon les fichiers modifiés :
+Les workflows sont déclenchés selon les fichiers modifiés :
 un workflow léger pour la documentation (`Docs CI`) ne lance que les vérifications
-Markdown et commitlint, tandis que le workflow principal s'active uniquement lorsque
-la configuration Ansible ou les scripts changent.
-Le lint Markdown s'appuie sur `.markdownlint.yml` pour ignorer les règles de
-longueur de ligne et d'espacement dans la documentation existante.
-Les tests s'exécutent pour chaque inventaire (`lab`, `staging`, `production`)
-via une matrice d'environnement.
-Sur `main`, un job de déploiement exécute `make deploy` pour chaque environnement.
+Markdown et commitlint, tandis que le workflow principal exécute les linters,
+teste chaque rôle dans un conteneur OpenWrt et déploie.
+Les tests s'exécutent une seule fois en utilisant l'inventaire `lab`.
+Sur `main`, un job de déploiement exécute `make deploy` pour chaque environnement (`lab`, `staging`, `production`).
 Le pipeline GitHub Actions met en cache
 `~/.cache/pip` et `~/.ansible` en fonction de
 `requirements.yml` et `.pre-commit-config.yaml` afin de réduire les téléchargements

--- a/docs/adr/0008-role-container-tests.md
+++ b/docs/adr/0008-role-container-tests.md
@@ -1,0 +1,14 @@
+# ADR 0008 - Tests de conformité des rôles en conteneur
+
+date: 2025-02-14
+
+## Contexte
+Seul le rôle `base` disposait d'un scénario Molecule et les autres rôles n'étaient pas vérifiés isolément. Cette situation exposait à des effets de bord lors des déploiements.
+
+## Décision
+Chaque rôle est désormais exécuté dans un conteneur OpenWrt éphémère pour vérifier son idempotence et sa conformité. L'outil Molecule est retiré au profit d'un script commun.
+
+## Conséquences
+- Couverture de tests homogène pour tous les rôles.
+- Pipeline CI simplifiée et plus rapide.
+- Réduction des dépendances (suppression de Molecule).

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,33 +1,49 @@
 #!/bin/bash
 set -e
 
-ENV=${ENV:-production}
+ENV=${ENV:-lab}
 INVENTORY="inventories/${ENV}/hosts.yml"
+IMAGE=${OPENWRT_IMAGE:-openwrt/rootfs:x86_64-23.05.6}
 
 for role in roles/*; do
-  if [ -d "$role/molecule" ]; then
-    (cd "$role" && molecule test)
+  role_name=$(basename "$role")
+  CONTAINER_NAME="test-${role_name}"
+  docker run -d --rm --name "$CONTAINER_NAME" "$IMAGE" /sbin/init >/dev/null
+  cat <<EOT >/tmp/inventory.docker
+[openwrt]
+$CONTAINER_NAME ansible_connection=community.docker.docker
+[openwrt:vars]
+backup_enabled=false
+EOT
+  cat <<EOT >/tmp/role.yml
+- hosts: openwrt
+  gather_facts: false
+  roles:
+    - $role_name
+EOT
+  ansible-playbook -i /tmp/inventory.docker /tmp/role.yml >/tmp/first.log
+  second_run=$(ansible-playbook -i /tmp/inventory.docker /tmp/role.yml)
+  echo "$second_run" >/tmp/second.log
+  if ! echo "$second_run" | grep -q 'changed=0.*failed=0'; then
+    echo "Role $role_name is not idempotent"
+    exit 1
   fi
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1
+  rm /tmp/inventory.docker /tmp/role.yml /tmp/first.log /tmp/second.log
 done
 
 ansible-playbook -i "$INVENTORY" --syntax-check playbooks/bootstrap.yml
 ansible-playbook -i "$INVENTORY" --syntax-check playbooks/site.yml
 
-# Run configuration against an ephemeral OpenWrt container
 CONTAINER_NAME=openwrt-test
-IMAGE=${OPENWRT_IMAGE:-openwrt/rootfs:x86_64-23.05.6}
-
 docker run -d --rm --name "$CONTAINER_NAME" "$IMAGE" /sbin/init >/dev/null
-trap 'docker rm -f $CONTAINER_NAME >/dev/null 2>&1' EXIT
-
-cat <<EOF > /tmp/inventory.docker
+cat <<EOT >/tmp/inventory.docker
 [openwrt]
 $CONTAINER_NAME ansible_connection=community.docker.docker
 [openwrt:vars]
 backup_enabled=false
-EOF
-
+EOT
 ansible-playbook -i /tmp/inventory.docker playbooks/bootstrap.yml
 ansible-playbook -i /tmp/inventory.docker playbooks/site.yml
-
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1
 rm /tmp/inventory.docker


### PR DESCRIPTION
## Summary
- validate roles in OpenWrt containers
- streamline CI workflow

## Testing
- [ ] `pre-commit run --all-files`
- [ ] `make test ENV=lab`

## Checklist
- [ ] Documentation updated
- [ ] ADR added
- [ ] Reviewers approved


------
https://chatgpt.com/codex/tasks/task_e_68c6c4a4f51c832b85e637725c0e5e62